### PR TITLE
feat!: security, performance, helpers, oh my!

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.4 ]
+        php: [ 8.2, 8.3, 8.4 ]
         laravel: [ 11.*, 12.* ]
         stability: [ prefer-lowest, prefer-stable ]
 

--- a/captainhook.json
+++ b/captainhook.json
@@ -1,0 +1,29 @@
+{
+  "commit-msg": {
+    "enabled": true,
+    "actions": [
+      {
+        "action": "\\Ramsey\\CaptainHook\\ValidateConventionalCommit"
+      }
+    ]
+  },
+  "pre-push": {
+    "enabled": true,
+    "actions": [
+      {
+        "action": "composer test"
+      },
+      {
+        "action": "composer analyse"
+      }
+    ]
+  },
+  "pre-commit": {
+    "enabled": true,
+    "actions": [
+      {
+        "action": "composer pint"
+      }
+    ]
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,20 +20,23 @@
     }
   ],
   "require": {
-    "php": "^8.4",
-    "illuminate/support": "^11.0|^12.0",
-    "illuminate/database": "^11.0|^12.0"
+    "php": "^8.2",
+    "illuminate/database": "^11.0|^12.0",
+    "illuminate/support": "^11.0|^12.0"
   },
   "require-dev": {
+    "captainhook/captainhook-phar": "^5.27",
     "larastan/larastan": "^3.8.1",
     "laravel/pint": "^1.26.0",
     "orchestra/testbench": "^9.0|^10.8.0",
     "pestphp/pest": "^3.0|^4.0",
-    "pestphp/pest-plugin-laravel": "^3.0|^4.0"
+    "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+    "ramsey/conventional-commits": "^1.6"
   },
   "autoload": {
     "psr-4": {
-      "OffloadProject\\InviteOnly\\": "src/"
+      "OffloadProject\\InviteOnly\\": "src/",
+      "OffloadProject\\InviteOnly\\Database\\Factories\\": "database/factories/"
     }
   },
   "autoload-dev": {
@@ -60,6 +63,7 @@
   },
   "config": {
     "allow-plugins": {
+      "captainhook/captainhook-phar": true,
       "pestphp/pest-plugin": true
     },
     "sort-packages": true

--- a/config/invite-only.php
+++ b/config/invite-only.php
@@ -30,6 +30,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Users Table Name
+    |--------------------------------------------------------------------------
+    |
+    | The name of the users table for foreign key constraints in migrations.
+    | This should match the table used by your user model.
+    |
+    */
+    'users_table' => 'users',
+
+    /*
+    |--------------------------------------------------------------------------
     | Expiration Settings
     |--------------------------------------------------------------------------
     |
@@ -80,11 +91,15 @@ return [
     |
     | Configure the routes for accepting and declining invitations.
     |
+    | SECURITY NOTE: It is strongly recommended to include rate limiting
+    | middleware (e.g., 'throttle:60,1') to prevent brute-force attacks
+    | on invitation tokens.
+    |
     */
     'routes' => [
         'enabled' => true,
         'prefix' => 'invitations',
-        'middleware' => ['web'],
+        'middleware' => ['web', 'throttle:60,1'],
     ],
 
     /*
@@ -92,13 +107,14 @@ return [
     | Redirect URLs
     |--------------------------------------------------------------------------
     |
-    | Where to redirect users after accepting, declining, or when an
-    | invitation has expired.
+    | Where to redirect users after accepting, declining, when an
+    | invitation has expired, or when an error occurs.
     |
     */
     'redirect' => [
         'accepted' => '/',
         'declined' => '/',
         'expired' => '/',
+        'error' => '/',
     ],
 ];

--- a/database/factories/InvitationFactory.php
+++ b/database/factories/InvitationFactory.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\InviteOnly\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use OffloadProject\InviteOnly\Enums\InvitationStatus;
+use OffloadProject\InviteOnly\Models\Invitation;
+
+/**
+ * @extends Factory<Invitation>
+ */
+final class InvitationFactory extends Factory
+{
+    protected $model = Invitation::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'email' => $this->faker->unique()->safeEmail(),
+            'token' => Invitation::generateToken(),
+            'status' => InvitationStatus::Pending,
+            'role' => null,
+            'metadata' => null,
+            'invitable_type' => null,
+            'invitable_id' => null,
+            'invited_by' => null,
+            'accepted_by' => null,
+            'expires_at' => now()->addDays(config('invite-only.expiration.days', 7)),
+            'accepted_at' => null,
+            'declined_at' => null,
+            'cancelled_at' => null,
+            'last_sent_at' => now(),
+            'reminder_count' => 0,
+        ];
+    }
+
+    /**
+     * Create a pending invitation.
+     */
+    public function pending(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'status' => InvitationStatus::Pending,
+            'accepted_at' => null,
+            'declined_at' => null,
+            'cancelled_at' => null,
+        ]);
+    }
+
+    /**
+     * Create an accepted invitation.
+     */
+    public function accepted(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'status' => InvitationStatus::Accepted,
+            'accepted_at' => now(),
+        ]);
+    }
+
+    /**
+     * Create a declined invitation.
+     */
+    public function declined(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'status' => InvitationStatus::Declined,
+            'declined_at' => now(),
+        ]);
+    }
+
+    /**
+     * Create an expired invitation.
+     */
+    public function expired(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'status' => InvitationStatus::Expired,
+            'expires_at' => now()->subDay(),
+        ]);
+    }
+
+    /**
+     * Create a cancelled invitation.
+     */
+    public function cancelled(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'status' => InvitationStatus::Cancelled,
+            'cancelled_at' => now(),
+        ]);
+    }
+
+    /**
+     * Set the invitation to never expire.
+     */
+    public function neverExpires(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'expires_at' => null,
+        ]);
+    }
+
+    /**
+     * Set custom expiration days.
+     */
+    public function expiresInDays(int $days): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'expires_at' => now()->addDays($days),
+        ]);
+    }
+
+    /**
+     * Set the invitation role.
+     */
+    public function withRole(string $role): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'role' => $role,
+        ]);
+    }
+
+    /**
+     * Set custom metadata.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    public function withMetadata(array $metadata): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'metadata' => $metadata,
+        ]);
+    }
+
+    /**
+     * Set the inviter.
+     */
+    public function invitedBy(int $userId): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'invited_by' => $userId,
+        ]);
+    }
+
+    /**
+     * Set who accepted the invitation.
+     */
+    public function acceptedBy(int $userId): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'accepted_by' => $userId,
+            'status' => InvitationStatus::Accepted,
+            'accepted_at' => now(),
+        ]);
+    }
+
+    /**
+     * Create an invitation that needs a reminder (created X days ago).
+     */
+    public function needsReminder(int $daysAgo = 3): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'status' => InvitationStatus::Pending,
+            'created_at' => now()->subDays($daysAgo),
+            'reminder_count' => 0,
+        ]);
+    }
+}

--- a/database/migrations/0001_01_01_000001_create_invitations_table.php
+++ b/database/migrations/0001_01_01_000001_create_invitations_table.php
@@ -10,7 +10,10 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create(config('invite-only.table', 'invitations'), function (Blueprint $table): void {
+        $tableName = config('invite-only.table', 'invitations');
+        $usersTable = config('invite-only.users_table', 'users');
+
+        Schema::create($tableName, function (Blueprint $table) use ($usersTable): void {
             $table->id();
             $table->nullableMorphs('invitable');
             $table->string('email');
@@ -18,8 +21,8 @@ return new class extends Migration
             $table->string('status')->default('pending');
             $table->string('role')->nullable();
             $table->json('metadata')->nullable();
-            $table->foreignId('invited_by')->nullable()->constrained('users')->nullOnDelete();
-            $table->foreignId('accepted_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('invited_by')->nullable()->constrained($usersTable)->nullOnDelete();
+            $table->foreignId('accepted_by')->nullable()->constrained($usersTable)->nullOnDelete();
             $table->timestamp('expires_at')->nullable();
             $table->timestamp('accepted_at')->nullable();
             $table->timestamp('declined_at')->nullable();

--- a/src/Contracts/InviteOnlyContract.php
+++ b/src/Contracts/InviteOnlyContract.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\InviteOnly\Contracts;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use InvalidArgumentException;
+use OffloadProject\InviteOnly\Exceptions\InvalidInvitationException;
+use OffloadProject\InviteOnly\Exceptions\InvitationAlreadyAcceptedException;
+use OffloadProject\InviteOnly\Exceptions\InvitationExpiredException;
+use OffloadProject\InviteOnly\Models\Invitation;
+
+interface InviteOnlyContract
+{
+    /**
+     * Create a new invitation.
+     *
+     * @param  array{role?: string, metadata?: array<string, mixed>, expires_at?: Carbon, invited_by?: Model|int}  $options
+     *
+     * @throws InvalidArgumentException When email format is invalid
+     */
+    public function invite(string $email, ?Model $invitable = null, array $options = []): Invitation;
+
+    /**
+     * Accept an invitation by token.
+     *
+     * @throws InvalidInvitationException When token is invalid, cancelled, or declined
+     * @throws InvitationAlreadyAcceptedException When invitation was already accepted
+     * @throws InvitationExpiredException When invitation has expired
+     */
+    public function accept(string $token, ?Model $user = null): Invitation;
+
+    /**
+     * Decline an invitation by token.
+     *
+     * @throws InvalidInvitationException When token is invalid or invitation is not pending
+     */
+    public function decline(string $token): Invitation;
+
+    /**
+     * Cancel an invitation.
+     *
+     * @throws InvalidInvitationException When invitation is not pending or not found
+     */
+    public function cancel(Invitation|int $invitation, bool $notify = false): Invitation;
+
+    /**
+     * Resend an invitation notification.
+     *
+     * @throws InvalidInvitationException When invitation is not valid
+     */
+    public function resend(Invitation|int $invitation): Invitation;
+
+    /**
+     * Find an invitation by token.
+     */
+    public function find(string $token): ?Invitation;
+
+    /**
+     * Find an invitation by email, optionally scoped to an invitable.
+     */
+    public function findByEmail(string $email, ?Model $invitable = null): ?Invitation;
+
+    /**
+     * Get pending invitations.
+     *
+     * @return Collection<int, Invitation>
+     */
+    public function pending(?Model $invitable = null): Collection;
+
+    /**
+     * Get accepted invitations.
+     *
+     * @return Collection<int, Invitation>
+     */
+    public function accepted(?Model $invitable = null): Collection;
+
+    /**
+     * Get declined invitations.
+     *
+     * @return Collection<int, Invitation>
+     */
+    public function declined(?Model $invitable = null): Collection;
+
+    /**
+     * Get expired invitations.
+     *
+     * @return Collection<int, Invitation>
+     */
+    public function expired(?Model $invitable = null): Collection;
+
+    /**
+     * Get cancelled invitations.
+     *
+     * @return Collection<int, Invitation>
+     */
+    public function cancelled(?Model $invitable = null): Collection;
+
+    /**
+     * Mark all past-expiration pending invitations as expired.
+     *
+     * @return int Number of invitations marked as expired
+     */
+    public function markExpiredInvitations(): int;
+
+    /**
+     * Send reminders for pending invitations.
+     *
+     * @return int Number of reminders sent
+     */
+    public function sendReminders(): int;
+}

--- a/src/Enums/InvitationStatus.php
+++ b/src/Enums/InvitationStatus.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\InviteOnly\Enums;
+
+enum InvitationStatus: string
+{
+    case Pending = 'pending';
+    case Accepted = 'accepted';
+    case Declined = 'declined';
+    case Expired = 'expired';
+    case Cancelled = 'cancelled';
+
+    public function isPending(): bool
+    {
+        return $this === self::Pending;
+    }
+
+    public function isAccepted(): bool
+    {
+        return $this === self::Accepted;
+    }
+
+    public function isDeclined(): bool
+    {
+        return $this === self::Declined;
+    }
+
+    public function isExpired(): bool
+    {
+        return $this === self::Expired;
+    }
+
+    public function isCancelled(): bool
+    {
+        return $this === self::Cancelled;
+    }
+
+    public function isTerminal(): bool
+    {
+        return in_array($this, [self::Accepted, self::Declined, self::Expired, self::Cancelled], true);
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Pending => 'Pending',
+            self::Accepted => 'Accepted',
+            self::Declined => 'Declined',
+            self::Expired => 'Expired',
+            self::Cancelled => 'Cancelled',
+        };
+    }
+}

--- a/src/Facades/InviteOnly.php
+++ b/src/Facades/InviteOnly.php
@@ -7,6 +7,7 @@ namespace OffloadProject\InviteOnly\Facades;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Facade;
+use OffloadProject\InviteOnly\Contracts\InviteOnlyContract;
 use OffloadProject\InviteOnly\Models\Invitation;
 
 /**
@@ -26,11 +27,12 @@ use OffloadProject\InviteOnly\Models\Invitation;
  * @method static int sendReminders()
  *
  * @see \OffloadProject\InviteOnly\InviteOnly
+ * @see InviteOnlyContract
  */
 final class InviteOnly extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-        return 'invite-only';
+        return InviteOnlyContract::class;
     }
 }

--- a/src/InviteOnlyServiceProvider.php
+++ b/src/InviteOnlyServiceProvider.php
@@ -7,6 +7,7 @@ namespace OffloadProject\InviteOnly;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use OffloadProject\InviteOnly\Console\SendInvitationRemindersCommand;
+use OffloadProject\InviteOnly\Contracts\InviteOnlyContract;
 use OffloadProject\InviteOnly\Http\Controllers\InvitationController;
 
 final class InviteOnlyServiceProvider extends ServiceProvider
@@ -15,7 +16,8 @@ final class InviteOnlyServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/invite-only.php', 'invite-only');
 
-        $this->app->singleton('invite-only', fn (): InviteOnly => new InviteOnly);
+        $this->app->singleton(InviteOnlyContract::class, InviteOnly::class);
+        $this->app->alias(InviteOnlyContract::class, 'invite-only');
     }
 
     public function boot(): void
@@ -42,11 +44,11 @@ final class InviteOnlyServiceProvider extends ServiceProvider
             ->middleware(config('invite-only.routes.middleware', ['web']))
             ->group(function (): void {
                 Route::get('{token}', [InvitationController::class, 'show'])
-                    ->name('invitations.show');
+                    ->name('invite-only.invitations.show');
                 Route::post('{token}/accept', [InvitationController::class, 'accept'])
-                    ->name('invitations.accept');
+                    ->name('invite-only.invitations.accept');
                 Route::post('{token}/decline', [InvitationController::class, 'decline'])
-                    ->name('invitations.decline');
+                    ->name('invite-only.invitations.decline');
             });
     }
 


### PR DESCRIPTION
New Features

- InvitationStatus Enum - Type-safe PHP 8.1 backed enum replacing string constants
- Helper methods: isPending(), isTerminal(), label()
- Automatic casting on the Invitation model
- InviteOnlyContract Interface - Allows custom implementations via dependency injection
- Model Factory - Invitation::factory() with state methods for testing
- States: pending(), accepted(), declined(), expired(), cancelled()
- Helpers: withRole(), withMetadata(), invitedBy(), expiresInDays(), needsReminder()

Security Improvements

- Email validation - Invalid emails now throw InvalidArgumentException
- Rate limiting - Default middleware includes throttle:60,1
- Configurable error redirects - Added redirect.error config option

Performance Improvements

- Batch updates - markExpiredInvitations() now uses single UPDATE query instead of N+1
- Efficient stats - getInvitationStats() uses database aggregation (GROUP BY) instead of loading all records into memory

Best Practices

- $guarded over $fillable - More secure mass assignment protection
- Prefixed route names - invite-only.invitations.* prevents conflicts
- Configurable users table - users_table config for custom table names in migrations
- whereNotNull() - Replaced where('expires_at', '!=', null) with proper method
- @throws annotations - Added to all methods that throw exceptions
- Deprecated constants - Old STATUS_* constants marked deprecated, pointing to enum

Code Quality

- Consolidated redirect helpers - Controller reduced from 5 methods to 1
- Simplified notification sending - Removed redundant method parameters
- PHP 8.1 minimum - Lowered from 8.4 for broader compatibility
