### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
   ],
   "require": {
     "php": "^8.2",
-    "illuminate/database": "^11.0|^12.0",
-    "illuminate/support": "^11.0|^12.0"
+    "illuminate/database": "^11.0|^12.0|^13.0",
+    "illuminate/support": "^11.0|^12.0|^13.0"
   },
   "require-dev": {
     "captainhook/captainhook-phar": "^5.27",
     "larastan/larastan": "^3.8.1",
     "laravel/pint": "^1.26.0",
-    "orchestra/testbench": "^9.0|^10.8.0",
+    "orchestra/testbench": "^9.0|^10.8.0|^11.0",
     "pestphp/pest": "^3.0|^4.0",
     "pestphp/pest-plugin-laravel": "^3.0|^4.0",
     "ramsey/conventional-commits": "^1.6"


### PR DESCRIPTION
## Summary
- Add `^13.0` to `illuminate/database` and `illuminate/support` version constraints
- Add `^11.0` to `orchestra/testbench` for Laravel 13 test compatibility

No breaking changes — Laravel 13 is backwards-compatible with the package's existing API.