### PR TITLE
deprecate: HasInvitations acceptedInvitations in favor of getAccepted…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,27 @@ class User extends Authenticatable
 }
 ```
 
+If a model both sends and receives invitations (e.g. user-to-user friend
+invitations), apply both traits. The two traits each define an
+`acceptedInvitations()` method, so use PHP's trait conflict resolution:
+
+```php
+use OffloadProject\InviteOnly\Traits\CanBeInvited;
+use OffloadProject\InviteOnly\Traits\HasInvitations;
+
+class User extends Authenticatable
+{
+    use HasInvitations, CanBeInvited {
+        CanBeInvited::acceptedInvitations insteadof HasInvitations;
+        HasInvitations::acceptedInvitations as acceptedInvitationsToModel;
+    }
+}
+```
+
+In v3.0 the `HasInvitations::acceptedInvitations()` helper will be removed in
+favour of `getAcceptedInvitations()`, eliminating the conflict — at which point
+the `insteadof`/`as` clauses can be dropped.
+
 ### 2. Send Invitations
 
 ```php

--- a/docs/howto/team-invitations.md
+++ b/docs/howto/team-invitations.md
@@ -75,7 +75,7 @@ public function invitations(Team $team)
 {
     return view('teams.invitations', [
         'pending' => $team->pendingInvitations(),
-        'accepted' => $team->acceptedInvitations(),
+        'accepted' => $team->getAcceptedInvitations(),
         'stats' => $team->getInvitationStats(),
     ]);
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -257,7 +257,8 @@ $team->invitations(): MorphMany
 $team->invite(string $email, array $options = []): Invitation
 $team->inviteMany(array $emails, array $options = []): BulkInvitationResult
 $team->pendingInvitations(): Collection
-$team->acceptedInvitations(): Collection
+$team->getAcceptedInvitations(): Collection
+$team->acceptedInvitations(): Collection  // Deprecated, removed in 3.0 — use getAcceptedInvitations()
 $team->validInvitations(): Collection
 $team->cancelInvitation(string $email, bool $notify = false): bool
 $team->resendInvitation(string $email): bool

--- a/src/Traits/HasInvitations.php
+++ b/src/Traits/HasInvitations.php
@@ -68,9 +68,21 @@ trait HasInvitations
      *
      * @return Collection<int, Invitation>
      */
-    public function acceptedInvitations(): Collection
+    public function getAcceptedInvitations(): Collection
     {
         return $this->invitations()->accepted()->get();
+    }
+
+    /**
+     * Get all accepted invitations for this model.
+     *
+     * @return Collection<int, Invitation>
+     *
+     * @deprecated 2.5.0 Use {@see self::getAcceptedInvitations()} instead. Will be removed in 3.0. Renamed so this trait can coexist with CanBeInvited (which defines an acceptedInvitations() relation) on the same model.
+     */
+    public function acceptedInvitations(): Collection
+    {
+        return $this->getAcceptedInvitations();
     }
 
     /**

--- a/tests/Feature/InvitationTest.php
+++ b/tests/Feature/InvitationTest.php
@@ -346,6 +346,26 @@ describe('HasInvitations trait', function (): void {
         expect($team->pendingInvitations())->toHaveCount(0);
     });
 
+    it('can get accepted invitations', function (): void {
+        $team = TestTeam::create(['name' => 'Test Team']);
+        $team->invite('pending@example.com');
+        $accepted = $team->invite('accepted@example.com');
+        $accepted->markAsAccepted();
+
+        $result = $team->getAcceptedInvitations();
+
+        expect($result)->toHaveCount(1);
+        expect($result->first()->email)->toBe('accepted@example.com');
+    });
+
+    it('exposes deprecated acceptedInvitations alias', function (): void {
+        $team = TestTeam::create(['name' => 'Test Team']);
+        $accepted = $team->invite('accepted@example.com');
+        $accepted->markAsAccepted();
+
+        expect($team->acceptedInvitations())->toHaveCount(1);
+    });
+
     it('can get invitation stats', function (): void {
         $team = TestTeam::create(['name' => 'Test Team']);
         $team->invite('pending@example.com');


### PR DESCRIPTION
Deprecating acceptedInvitations in HasInvitations in favor of getAcceptedInvitations to resolve trait conflict.